### PR TITLE
Fix bad English: "yestday" -> "yesterday"

### DIFF
--- a/src/CameraPhotosModel.cpp
+++ b/src/CameraPhotosModel.cpp
@@ -73,7 +73,7 @@ QVariant CameraPhotosModel::data(const QModelIndex &index, int role) const
             if (dayoffset < 1) {
                 dateString = qdate.toString(currentDayString);
             } else if (dayoffset == 1) {
-                dateString = i18n("yestday ")+ qdate.toString(currentDayString);
+                dateString = i18n("yesterday ")+ qdate.toString(currentDayString);
             } else {
                 dateString =  qdate.toString("dddd " + currentDayString);
             }


### PR DESCRIPTION
"Yestday" is not an English word. The word you're probably looking for is "yesterday."